### PR TITLE
core: Update to from jtag_vpi-r2 to jtag_vpi-r5

### DIFF
--- a/de0_nano-1.1.core
+++ b/de0_nano-1.1.core
@@ -44,7 +44,7 @@ filesets:
     depend:
       #isim and xsim doesn't handle vpi
       - "!isim? (!xsim? (>=::elf-loader:1.0.2))"
-      - "!isim? (!xsim? (jtag_vpi-r2))"
+      - "!isim? (!xsim? (>=::jtag_vpi:0-r5))"
       - ">=vlog_tb_utils-1.0"
       - mt48lc16m16a2
       - s25fl064p


### PR DESCRIPTION
The older core is no longer available in new repo's like fusesoc-cores etc.  Testing with icarus simulations and jtag_vpi-r5 works fine.