### PR TITLE
A few cleanups for the de0 nano system

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,25 @@ To build and program this to your FPGA board use:
 fusesoc library add de0_nano https://github.com/olofk/de0_nano.git
 
 # Build the bitstream
-fusesoc build de0_nano
+fusesoc run de0_nano
 # Program the bitstream to your board over usb-blaster
-fusesoc pgm de0_nano
+fusesoc run --run de0_nano --pgm quartus
 ```
 
-See the [OpenRISC de0 nano tutorial](https://github.com/openrisc/tutorials/tree/master/de0_nano) for more details.
+To run the board simulation we could use:
+
+```
+fusesoc run --target sim de0_nano --jtag_vpi_enable
+```
+
+See the [OpenRISC de0 nano tutorial](https://openrisc.io/tutorials/de0_nano/) for more details.
 
 ## Parameters
 
 The following parameters are available to be set during simulation.
 
- `bootrom_file` - initail contents of the boot ROM (used with `fusesoc sim`). See `/sw/` directory for an example.
- `spi_flash_file` - initail contents of the SPI Flash (used with `fusesoc sim`). See `/bench/` directory for an example.
+ `bootrom_file` - initail contents of the boot ROM (used with `fusesoc run --target sim`). See `/sw/` directory for an example.
+ `spi_flash_file` - initail contents of the SPI Flash (used with `fusesoc run --target sim`). See `/bench/` directory for an example.
 
 ## Bootloader
 

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,5 +1,8 @@
 BOOTROM_ADDR ?= 0x80000
 RESET_VECTOR ?= 0x100
+# Default loads binaries straight to reset vector,
+# override to 0x0 for already offset elf binaries.
+LOAD_ADDRESS ?= 0x100
 IMAGE ?= spi_image
 IMAGE_NAME ?= $(IMAGE)
 
@@ -11,12 +14,14 @@ all: $(IMAGE).vh
 %.bin: %.elf
 	or1k-elf-objcopy -O binary $< $@
 
+# The spi image is a u-boot image and can be up to 8MB, the size of the
+# EPCS64.
 %.ub: %.bin
 	mkimage \
 	-A or1k \
 	-C none \
 	-T standalone \
-	-a 0x100 \
+	-a $(LOAD_ADDRESS) \
 	-e $(RESET_VECTOR) \
 	-n '$@' \
 	-d $< \

--- a/bench/Makefile
+++ b/bench/Makefile
@@ -1,3 +1,5 @@
+# A make file for de0 nano SPI Images
+
 BOOTROM_ADDR ?= 0x80000
 RESET_VECTOR ?= 0x100
 # Default loads binaries straight to reset vector,

--- a/bench/de0_nano_core_tb.v
+++ b/bench/de0_nano_core_tb.v
@@ -156,6 +156,16 @@ de0_nano_core
  .wb_rst (~rst_n),
  .sdram_clk (clk),
  .sdram_rst (~rst_n),
+ 
+ .dbg_if_select_i(dbg_if_select),
+ .dbg_if_tdo_o(dbg_if_tdo),
+ .dbg_tck_i(dbg_tck),
+ .jtag_tap_tdo_i(jtag_tap_tdo),
+ .jtag_tap_shift_dr_i(jtag_tap_shift_dr),
+ .jtag_tap_pause_dr_i(jtag_tap_pause_dr),
+ .jtag_tap_update_dr_i(jtag_tap_update_dr),
+ .jtag_tap_capture_dr_i(jtag_tap_capture_dr),
+ 
  .gpio0_io (),
  .gpio1_i (4'h0),
 	//JTAG interface

--- a/rtl/verilog/de0_nano_core.v
+++ b/rtl/verilog/de0_nano_core.v
@@ -224,7 +224,17 @@ mor1kx #(
 //
 ////////////////////////////////////////////////////////////////////////
 
-adbg_top dbg_if0 (
+adbg_top #(
+	.DBG_WISHBONE_SUPPORTED("ENABLED"),
+	.DBG_CPU0_SUPPORTED("ENABLED"),
+	.DBG_CPU1_SUPPORTED("NONE"),
+	// Disable the JTAG Serial Port (JSP)
+	.DBG_JSP_SUPPORTED("NONE"),
+	// If this is enabled, status bits will be skipped on burst
+	// reads and writes to improve download speeds.  OpenOCD
+	// expects it to be enabled.
+	.ADBG_USE_HISPEED("ENABLED")
+) dbg_if0 (
 	// OR1K interface
 	.cpu0_clk_i	(wb_clk),
 	.cpu0_rst_o	(or1k_dbg_rst),

--- a/sw/Makefile
+++ b/sw/Makefile
@@ -1,3 +1,5 @@
+# A make file for de0 nano bootrom images
+
 BOOTROM_ADDR ?= 0x80000
 
 TARGET ?= spi_uimage_loader

--- a/sw/clear_r3_and_jump_to_0x100.S
+++ b/sw/clear_r3_and_jump_to_0x100.S
@@ -1,0 +1,13 @@
+/*
+ * A bootrom image for use in simulations where memory can be
+ * pre loaded by elf-loaders. Clears registers and jumps to 0x100.
+ */
+
+#define OR1K_RESET_VECTOR 0x100
+
+bootrom_init:
+	l.movhi	r0, 0x0
+	l.movhi	r3, hi(OR1K_RESET_VECTOR)
+	l.ori	r3, r3, lo(OR1K_RESET_VECTOR)
+	l.jr	r3
+	 l.nop


### PR DESCRIPTION
I was trying to get the de0 nano board to build and run again on my board.  But I was getting CRC errors during burst writes over the JTAG debug interface.   I thought there was a problem with the JTAG/adv_debug_sys so tested using jtag over VPI and simulating adv_debug_sys, and there were no issues.

In the end the issue seems to be with openocd, downgrading to openocd 0.10.0 allows everything to work again.

However, I think the cleanups I added are worth upstreaming.